### PR TITLE
Modify Dockerfile to "work"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,27 +13,27 @@ WORKDIR /opt/outflux
 ## This does not work for now. Only starting with yarn develop and
 ## with all the dev dependencies installed has a successful app startup
 
-# FROM --platform=linux/amd64 node:18.14-alpine as prod-install
+FROM --platform=linux/amd64 node:18.14-alpine as prod-install
 
-#     WORKDIR /opt/outflux 
+    WORKDIR /opt/outflux 
 
-#     COPY package*.json ./
-#     COPY yarn*.lock ./
-#     RUN yarn install --production=true --frozen-lockfile
+    COPY package*.json ./
+    COPY yarn*.lock ./
+    RUN yarn install --production=true --frozen-lockfile
 
-# FROM --platform=linux/amd64 node:18.14-alpine
+FROM --platform=linux/amd64 node:18.14-alpine
 
-#     WORKDIR /opt/outflux 
-#     COPY --from=dev-build /opt/outflux/dist/ ./dist/
-#     COPY --from=prod-install /opt/outflux/node_modules/ ./node_modules/
+    WORKDIR /opt/outflux 
+    COPY --from=dev-build /opt/outflux/dist/ ./dist/
+    COPY --from=prod-install /opt/outflux/node_modules/ ./node_modules/
 
-#     COPY package*.json ./
-#     COPY yarn*.lock ./
+    COPY package*.json ./
+    COPY yarn*.lock ./
     
-#     RUN apk add --update --no-cache python3
-#     RUN ln -sf /usr/bin/python3 /usr/bin/python
+    RUN apk add --update --no-cache python3
+    RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 EXPOSE 5000
 
-# CMD ["yarn", "start"]
-CMD ["yarn", "develop"]
+CMD ["yarn", "start"]
+# CMD ["yarn", "develop"]


### PR DESCRIPTION
The app doesn't start with `yarn start` and thus the Dockerfile will never work. I've reverted it to the full dev dependencies layer which is how developers are using the app so far until we find a better way